### PR TITLE
use a filename for the regex instead of dot delimited

### DIFF
--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -72,7 +72,7 @@ DEF_OMOD_STATIC_DATA
 DEFobjCurrIf(errmsg)
 DEFobjCurrIf(regexp)
 
-#define DFLT_FILENAME_REGEX "var\\.log\\.containers\\.([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_([^_]+)_(.+)-([a-z0-9]{64})\\.log$"
+#define DFLT_FILENAME_REGEX "var/log/containers/([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_([^_]+)_(.+)-([a-z0-9]{64})\\.log$"
 #define DFLT_SRCMD_PATH "$!metadata!filename"
 #define DFLT_DSTMD_PATH "$!metadata"
 


### PR DESCRIPTION
The fluentd k8s metadata plugin uses dots for the component delimiters
because the fluentd in_tail plugin with the '_' wildcard pre-processes
the filename matched by '_' into a tag, with the tag components
delimited by dot.  Instead, in rsyslog, the metadata is passed as
the actual filename, delimited by '/'.
